### PR TITLE
Remove pingdom tracking/analytics.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -40,18 +40,6 @@
   <link rel="stylesheet" href="css/styles.css">
   <!-- endbuild -->
 
-  <!-- Pingdom -->
-  <script>
-  var _prum = [['id', '5734a79eabe53d08424f86dd'],
-              ['mark', 'firstbyte', (new Date()).getTime()]];
-  (function() {
-      var s = document.getElementsByTagName('script')[0]
-        , p = document.createElement('script');
-      p.async = 'async';
-      p.src = '//rum-static.pingdom.net/prum.min.js';
-      s.parentNode.insertBefore(p, s);
-  })();
-  </script>
 </head>
 
 <body>

--- a/app/index.html
+++ b/app/index.html
@@ -44,11 +44,13 @@
 
 <body>
 <a href="#skip" tabindex="1" class="skip-to-content" data-translate>Skip to Main Content</a>
+<!--
 <div class="alert alert-warning m-margin-bottom-0 ng-cloak" ng-if="config.apiIsMismatched">
   <a onclick="window.location.reload()" href="#">
     A newer version of this software is available. Click here to refresh the page. <i class="fa fa-lg fa-refresh"></i>
   </a>
 </div>
+-->
 <div id="notification"></div>
 
 <div id="wrapper" aria-busy="true" aria-live="assertive">


### PR DESCRIPTION
I noticed that the GDC site uses Pingdom (www.pingdom.com) for performance analytics. I've removed the relevant block from our index.html so as not to mess up their statistics with our testing. I'm not sure if it's really a problem, but since we're not signed up for this service there's no reason for us to be including their code. Also commented out the alert div that was causing extraneous whitespace below the header.
