### PR TITLE
Allow duplicates in project list, report unique projects on home page.

### DIFF
--- a/app/scripts/home/home.controllers.ts
+++ b/app/scripts/home/home.controllers.ts
@@ -160,6 +160,18 @@ module ngApp.home.controllers {
         return;
       }
 
+      // allow duplicate project ids, count the number of unique projects
+      project_ids = {};
+      n_unique_project_ids = 0;
+	
+      _.map(hits, function(hit) {
+      	  if !(hit.project_id in project_ids) {
+	      ++n_unique_project_ids;
+      	      project_ids[hit.project_id] = 1;
+	  }
+      });
+
+      data.pagination.unique_total = n_unique_project_ids;
 
       // reduce the array keyed on projectID
       var primarySites = _.reduce(hits, function(primarySiteData, project) {

--- a/app/scripts/home/templates/home.html
+++ b/app/scripts/home/templates/home.html
@@ -83,7 +83,7 @@
           <div class="stats-block-header">Projects</div>
           <div class="stats-block-body">
             <i class="icon-gdc-projects project-icon"></i>
-            <span style="color: #333" data-ng-bind="hc.projectData.pagination.total|number"></span>
+            <span style="color: #333" data-ng-bind="hc.projectData.pagination.unique_total|number"></span>
           </div>
         </div>
         <div class="data-stats-block">


### PR DESCRIPTION
Moving towards allowing duplicate project ids in some of the return values. This reverse-compatible change modifies the home page to report the number of _unique_ project ids in the "PROJECTS" summary box.
